### PR TITLE
[dev sqflite]複数アカウント対応？

### DIFF
--- a/lib/pages/testhome.dart
+++ b/lib/pages/testhome.dart
@@ -17,7 +17,7 @@ class Testhome extends ConsumerWidget {
     final beacon = ref.watch(beaconProvider);
     final userData = ref.watch(userDataProvider);
 
-    final Sqlite sqlite = Sqlite();
+    final Sqlite sqlite = Sqlite(Supabase.instance.client.auth.currentUser!.id);
 
     // Supabase.instance.client.auth.onAuthStateChange.listen((data) {
     //   final AuthChangeEvent event = data.event;
@@ -93,7 +93,7 @@ class Testhome extends ConsumerWidget {
             // ),
             ElevatedButton(
                 onPressed: () {
-                  sqlite.deleteDatabase();
+                  sqlite.deleteDatabase(Supabase.instance.client.auth.currentUser!.id);
                 },
                 child: const Text('delete table')),
             const Text('Scanned devices:'),

--- a/lib/utils/sqlite.dart
+++ b/lib/utils/sqlite.dart
@@ -5,19 +5,19 @@ import 'package:sysdev_suretti/models/scanned_user.dart';
 class Sqlite {
   late final Future<Database> _database;
 
-  Sqlite() {
-    _database = _open();
+  Sqlite(String authId) {
+    _database = _open(authId);
   }
 
   /// SQLiteデータベースを開く
   ///
   /// @return Future<Database>
-  Future<Database> _open() async {
+  Future<Database> _open(String id) async {
     const sql = {
       '2': ['']
     };
     return openDatabase(
-      join(await getDatabasesPath(), 'suretti.db'),
+      join(await getDatabasesPath(), '$id-suretti.db'),
       version: 1,
       onCreate: (db, version) {
         return db.execute(
@@ -36,9 +36,10 @@ class Sqlite {
   }
 
   /// データベース削除
-  Future<void> deleteDatabase() async {
-    final db = await _database;
-    await db.delete('scanned_user');
+  Future<void> deleteDatabase(String id) async {
+    // final db = await _database;
+    // await db.delete('scanned_user');
+    databaseFactory.deleteDatabase(join(await getDatabasesPath(), '$id-suretti.db'),);
   }
 
   /// スキャンしたユーザーデータを登録する


### PR DESCRIPTION
データベース名にアカウントIDの接頭辞をつけることで、ログアウトした後にほかのアカウントでログインしなおしたときに情報が混ざらないようにした
要するに、アカウントごとに別のデータベースが端末に作成されるようになった